### PR TITLE
Fix `math.Rand`

### DIFF
--- a/php/math.go
+++ b/php/math.go
@@ -165,7 +165,7 @@ func Rand(args ...int) int {
 	} else if l > 0 {
 		return rand.Intn(args[0])
 	} else {
-		return rand.Intn(1 << 32)
+		return rand.Int()
 	}
 }
 


### PR DESCRIPTION
https://github.com/awesee/php2go/blob/main/php/math.go#L168

Mac 下没有问题，Linux、Windows 报 `php/math.go:168:22: constant 4294967296 overflows int` 错误。

亲测可改成修复

```go
// rand.Intn(1<<31 - 1)
return rand.Int()
```